### PR TITLE
Fix output for component description

### DIFF
--- a/lib/template.pug
+++ b/lib/template.pug
@@ -20,7 +20,7 @@ html(lang="en")
       each component in document.components
         .component
           h2=component.name
-          .details=component.details
+          .details=component.description
           .component-demo!=component.markup
           pre.html=component.markup
           pre.css


### PR DESCRIPTION
topdoc uses the keyword `description` in the block comment. `component.details` is not one of the predefined keywords. Replace with `component.description` to fix output.